### PR TITLE
Samples refactoring

### DIFF
--- a/package-samples/.project
+++ b/package-samples/.project
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+  <name>package</name>
+  <comment>Build package distributions of nuxeo applications. NO_M2ECLIPSE_SUPPORT: Project files created with the maven-eclipse-plugin are not supported in M2Eclipse.</comment>
+  <projects/>
+  <buildSpec/>
+  <natures/>
+</projectDescription>

--- a/package-samples/.settings/org.eclipse.jdt.core.prefs
+++ b/package-samples/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,5 @@
+#Wed Aug 19 18:12:53 CEST 2015
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8

--- a/package-samples/pom.xml
+++ b/package-samples/pom.xml
@@ -8,7 +8,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
 
-  <artifactId>package</artifactId>
+  <artifactId>package-samples</artifactId>
   <name>Template rendering samples Marketplace package</name>
   <packaging>zip</packaging>
 

--- a/package-samples/pom.xml
+++ b/package-samples/pom.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.nuxeo.template.rendering</groupId>
+    <artifactId>marketplace-parent</artifactId>
+    <version>6.5.3-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>package</artifactId>
+  <name>Template rendering samples Marketplace package</name>
+  <packaging>zip</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.nuxeo.template.rendering</groupId>
+      <artifactId>nuxeo-template-rendering-samples</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>nuxeo-studio</groupId>
+      <artifactId>template-module-demo</artifactId>
+      <version>0.0.0-SNAPSHOT</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.nuxeo.build</groupId>
+        <artifactId>ant-assembly-maven-plugin</artifactId>
+        <configuration>
+          <buildFiles>
+            <buildFile>${basedir}/src/main/assemble/assembly.xml</buildFile>
+          </buildFiles>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/package-samples/src/main/assemble/assembly.xml
+++ b/package-samples/src/main/assemble/assembly.xml
@@ -14,25 +14,20 @@
   </target>
 
   <target name="expand">
-    <!-- Include your artifacts in the graph adding your groupId to groupPrefixes -->
     <artifact:nuxeo-expand includeTestScope="true"
-                           groupPrefixes="org.nuxeo,com.nuxeo" />
-    <!-- For Nuxeo IDE being able to use that distribution as a SDK -->
+                           groupPrefixes="org.nuxeo" />
     <artifact:print output="${outdir}/artifacts-rendering.properties"
                     mode="sdk" />
     <artifact:print output="${outdir}/test-artifacts-rendering.properties"
                     mode="sdk"
                     scopes="test" />
-    <!-- Prints the graph for debugging purpose -->
     <artifact:print output="${outdir}/dependency-tree.log" />
   </target>
 
   <target name="build"
           depends="init"
-          description="Build template rendering Marketplace package">
+          description="Build template rendering samples Marketplace package">
     <tstamp />
-    <delete failonerror="false" dir="${outdir}/nxr" />
-    <mkdir dir="${outdir}/nxr" />
     <delete failonerror="false" dir="${outdir}/marketplace" />
     <mkdir dir="${outdir}/marketplace" />
     <copy todir="${outdir}/marketplace">
@@ -47,71 +42,17 @@
     <copy file="${outdir}/test-artifacts-rendering.properties"
           todir="${outdir}/marketplace/install" />
 
-    <!-- Base distribution NXR -->
-    <copy todir="${outdir}">
-      <artifact:resolveFile key="org.nuxeo.ecm.distribution:nuxeo-distribution-cap::zip" />
-    </copy>
-
     <!-- Nuxeo bundles -->
-    <copy todir="${outdir}/nxr/bundles" overwrite="true">
-      <artifact:set>
-        <includes>
-          <artifact groupId="org.nuxeo*" scope="!test" type="!pom" />
-        </includes>
-      </artifact:set>
+    <copy todir="${outdir}/marketplace/install/bundles" overwrite="true">
+    	<artifact:file artifactId="nuxeo-template-rendering-samples" />
+    	<artifact:file artifactId="template-module-demo" />
     </copy>
-    <!-- Third-party libraries -->
-    <copy todir="${outdir}/nxr/lib" overwrite="true">
-      <artifact:set>
-        <includes>
-          <artifact groupId="!org.nuxeo*" scope="!test" />
-        </includes>
-        <excludes>
-          <!-- Filter out your artifacts using their groupId for instance -->
-          <artifact groupId="com.nuxeo*" />
-        </excludes>
-      </artifact:set>
-    </copy>
-    <move todir="${outdir}/nxr/lib">
-      <fileset dir="${outdir}/nxr/bundles">
-        <include name="nuxeo-generic-wss-front*" />
-        <include name="nuxeo-generic-wss-handler*" />
-      </fileset>
-    </move>
-    <!-- rename jexl2 so that update system does not remplace jexl 1 lib that is already part of Nuxeo -->
-    <nx:rename from="${outdir}/nxr/lib/commons-jexl-2*"
-               to="${outdir}/nxr/lib/commons-jexl2-do-not-remove-2.jar" />
-    <nx:rmdups dir="${outdir}/nxr/lib" />
-    <!-- Temporary ZIP Nuxeo NXR to compare with base distribution NXR -->
-    <zip destfile="${outdir}/nxr-${maven.project.version}.zip"
-         basedir="${outdir}/nxr" />
-
-    <!-- Your MP only needs to include files not already provided by the base distribution -->
-    <nx:zipdiff file1="${outdir}/nxr-${maven.project.version}.zip"
-                file2="${outdir}/nuxeo-distribution-cap-${nuxeo.distribution.version}.zip"
-                includesfile="${outdir}/includes"
-                excludesfile="${outdir}/excludesfile"
-                patternsetid="rendering.versus.cap">
-    </nx:zipdiff>
-    <unzip src="${outdir}/nxr-${maven.project.version}.zip"
-           dest="${outdir}/marketplace/install">
-      <patternset refid="rendering.versus.cap" />
-    </unzip>
 
     <!-- Generate install.xml file -->
-    <!-- See documentation at http://doc.nuxeo.com/x/IgIz -->
     <var name="install.content" value="&lt;install&gt;" />
     <var name="install.content"
          value="${install.content}${line.separator}
   &lt;update file=&quot;${package.root}/install/bundles&quot; todir=&quot;${env.bundles}&quot; /&gt;" />
-    <if>
-      <available file="${outdir}/marketplace/install/lib" />
-      <then>
-        <var name="install.content"
-             value="${install.content}${line.separator}
-  &lt;update file=&quot;${package.root}/install/lib&quot; todir=&quot;${env.lib}&quot; /&gt;" />
-      </then>
-    </if>
     <var name="install.content"
          value="${install.content}${line.separator}
   &lt;copy file=&quot;${package.root}/install/artifacts-rendering.properties&quot;${line.separator}

--- a/package-samples/src/main/resources/package.xml
+++ b/package-samples/src/main/resources/package.xml
@@ -1,0 +1,22 @@
+<package type="addon" name="nuxeo-template-rendering-samples" version="@VERSION@">
+  <title>Template Rendering Samples</title>
+  <description>
+    <p>Provides samples for the template rendering add-on.</p>
+  </description>
+  <home-page>https://github.com/nuxeo/nuxeo-template-rendering</home-page>
+  <vendor>Nuxeo</vendor>
+  <installer restart="true" />
+  <uninstaller restart="true" />
+  <nuxeo-validation>nuxeo_certified</nuxeo-validation>
+  <production-state>production_ready</production-state>
+  <supported>true</supported>
+  <platforms>
+    <platform>cap-@DISTRIB_VERSION@</platform>
+  </platforms>
+  <dependencies>
+     <package>nuxeo-template-rendering</package>
+  </dependencies>
+  <license>LGPL 2.1</license>
+  <license-url>http://www.gnu.org/licenses/lgpl-2.1.html</license-url>
+  <visibility>PUBLIC</visibility>
+</package>

--- a/package/.project
+++ b/package/.project
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+  <name>package</name>
+  <comment>Build package distributions of nuxeo applications. NO_M2ECLIPSE_SUPPORT: Project files created with the maven-eclipse-plugin are not supported in M2Eclipse.</comment>
+  <projects/>
+  <buildSpec/>
+  <natures/>
+</projectDescription>

--- a/package/.settings/org.eclipse.jdt.core.prefs
+++ b/package/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,5 @@
+#Wed Aug 19 18:15:05 CEST 2015
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=1.8
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.source=1.8
+org.eclipse.jdt.core.compiler.compliance=1.8

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -43,10 +43,6 @@
       <artifactId>nuxeo-template-rendering-web</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.nuxeo.template.rendering</groupId>
-      <artifactId>nuxeo-template-rendering-samples</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.nuxeo.ecm.platform</groupId>
       <artifactId>nuxeo-platform-rendition-core</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
 
   <modules>
     <module>package</module>
+    <module>package-samples</module>
   </modules>
 
   <profiles>
@@ -25,9 +26,6 @@
       <id>ftest</id>
       <modules>
         <module>ftest/webdriver</module>
-        <!-- <module>ftest/selenium</module> -->
-        <!-- <module>ftest/funkload</module> -->
-        <!-- <module>ftest/cmis</module> -->
       </modules>
     </profile>
   </profiles>


### PR DESCRIPTION
# NXP-17518 & NXP-17519

Samples for template rendering module have been refactored to be more user friendly and appealing. Packaging needs to be updated correspondingly.
## Goals
### Two separate marketplace packages should be offered:
- template rendering 
- and template rendering samples

Template Rendering Samples depend on Template Rendering
## Impacts that will need work
- Jenkins jobs need to be updated
- Template Rendering Samples should be the mp offered by default for a new install
- The mp requires the Nuxeo Studio template-module-demo project, before every release the Studio project needs to be checked / updated
## Important

See also the corresponding pull request created for nuxeo-template-rendering!
