### PR TITLE
NXP-17519 - Update packaging for samples refactoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 target
+.project
+.settings/
+

--- a/ftest/webdriver/itests.xml
+++ b/ftest/webdriver/itests.xml
@@ -9,7 +9,7 @@
   </unzip>
   <import file="${out.dir}/nuxeo-ftest.xml" />
 
-  <property name="mp.install" value="file:${out.dir}/package-${marketplace.rendering.version}.zip" />
+  <property name="mp.install" value="file:${out.dir}/package-${maven.project.version}.zip" />
   <target name="prepare-environment" depends="_init,prepare-db,prepare-tomcat,prepare-jboss">
     <copy todir="${out.dir}">
       <artifact:file key="org.nuxeo.template.rendering:package::zip" />

--- a/package-samples/pom.xml
+++ b/package-samples/pom.xml
@@ -1,0 +1,40 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.nuxeo.template.rendering</groupId>
+    <artifactId>marketplace-parent</artifactId>
+    <version>6.5.3-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>package-samples</artifactId>
+  <name>Template rendering samples Marketplace package</name>
+  <packaging>zip</packaging>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.nuxeo.template.rendering</groupId>
+      <artifactId>nuxeo-template-rendering-samples</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>nuxeo-studio</groupId>
+      <artifactId>template-module-demo</artifactId>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.nuxeo.build</groupId>
+        <artifactId>ant-assembly-maven-plugin</artifactId>
+        <configuration>
+          <buildFiles>
+            <buildFile>${basedir}/src/main/assemble/assembly.xml</buildFile>
+          </buildFiles>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/package-samples/src/main/assemble/assembly.xml
+++ b/package-samples/src/main/assemble/assembly.xml
@@ -1,0 +1,61 @@
+<project name="template-rendering-sample-assembly"
+         default="build"
+         xmlns:nx="urn:nuxeo-build"
+         xmlns:artifact="urn:nuxeo-artifact">
+  <taskdef resource="org/nuxeo/build/antlib.xml" uri="urn:nuxeo-build" />
+  <taskdef resource="org/nuxeo/build/artifact/antlib.xml" uri="urn:nuxeo-artifact" />
+  <taskdef resource="net/sf/antcontrib/antlib.xml" />
+
+  <target name="init" unless="init.done">
+    <property name="outdir" value="${maven.project.build.directory}" />
+    <delete failonerror="false" dir="${outdir}/marketplace" />
+    <mkdir dir="${outdir}/marketplace/install" />
+    <antcall target="expand" />
+    <property name="init.done" value="true" />
+  </target>
+
+  <target name="expand">
+    <artifact:nuxeo-expand includeTestScope="true" groupPrefixes="org.nuxeo" />
+    <artifact:print output="${outdir}/marketplace/install/artifacts-rendering-samples.properties" mode="sdk" />
+    <artifact:print output="${outdir}/marketplace/install/test-artifacts-rendering-samples.properties"
+                    mode="sdk"
+                    scopes="test" />
+    <artifact:print output="${outdir}/dependency-tree.log" />
+  </target>
+
+  <target name="build" depends="init" description="Build template rendering samples Marketplace package">
+    <tstamp />
+    <copy todir="${outdir}/marketplace">
+      <fileset dir="src/main/resources" />
+      <filterset>
+        <filter token="VERSION" value="${maven.project.version}" />
+        <filter token="DISTRIB_VERSION" value="${nuxeo.distribution.version}" />
+      </filterset>
+    </copy>
+
+    <!-- Nuxeo bundles -->
+    <copy todir="${outdir}/marketplace/install/bundles" overwrite="true">
+      <artifact:file artifactId="nuxeo-template-rendering-samples" />
+      <artifact:file artifactId="template-module-demo" />
+    </copy>
+
+    <!-- Generate install.xml file -->
+    <var name="install.content" value="&lt;install&gt;" />
+    <var name="install.content"
+         value="${install.content}${line.separator}
+  &lt;update file=&quot;${package.root}/install/bundles&quot; todir=&quot;${env.bundles}&quot; /&gt;" />
+    <var name="install.content"
+         value="${install.content}${line.separator}
+  &lt;copy file=&quot;${package.root}/install/artifacts-rendering-samples.properties&quot;${line.separator}
+    todir=&quot;${env.server.home}/sdk&quot; overwrite=&quot;true&quot; /&gt;${line.separator}
+  &lt;copy file=&quot;${package.root}/install/test-artifacts-rendering-samples.properties&quot;${line.separator}
+    todir=&quot;${env.server.home}/sdk&quot; overwrite=&quot;true&quot; /&gt;${line.separator}
+&lt;/install&gt;${line.separator}" />
+    <echo file="${outdir}/marketplace/install.xml" message="${install.content}" />
+
+    <zip destfile="${outdir}/${maven.project.artifactId}-${maven.project.version}.zip"
+         basedir="${outdir}/marketplace" />
+    <artifact:attach file="${outdir}/${maven.project.artifactId}-${maven.project.version}.zip" type="zip" />
+  </target>
+
+</project>

--- a/package-samples/src/main/resources/package.xml
+++ b/package-samples/src/main/resources/package.xml
@@ -1,0 +1,22 @@
+<package type="addon" name="nuxeo-template-rendering-samples" version="@VERSION@">
+  <title>Template Rendering Samples</title>
+  <description>
+    <p>Provides samples for the template rendering add-on.</p>
+  </description>
+  <home-page>https://github.com/nuxeo/nuxeo-template-rendering</home-page>
+  <vendor>Nuxeo</vendor>
+  <installer restart="true" />
+  <uninstaller restart="true" />
+  <nuxeo-validation>nuxeo_certified</nuxeo-validation>
+  <production-state>production_ready</production-state>
+  <supported>true</supported>
+  <platforms>
+    <platform>cap-@DISTRIB_VERSION@</platform>
+  </platforms>
+  <dependencies>
+     <package>nuxeo-template-rendering</package>
+  </dependencies>
+  <license>LGPL 2.1</license>
+  <license-url>http://www.gnu.org/licenses/lgpl-2.1.html</license-url>
+  <visibility>PUBLIC</visibility>
+</package>

--- a/package/pom.xml
+++ b/package/pom.xml
@@ -50,10 +50,6 @@
       <artifactId>nuxeo-template-rendering-web</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.nuxeo.template.rendering</groupId>
-      <artifactId>nuxeo-template-rendering-samples</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.nuxeo.ecm.platform</groupId>
       <artifactId>nuxeo-platform-rendition-core</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -13,12 +13,9 @@
   <name>Nuxeo Marketplace package for template rendering</name>
   <version>6.5.3-SNAPSHOT</version>
 
-  <properties>
-    <marketplace.rendering.version>6.5.3-SNAPSHOT</marketplace.rendering.version>
-  </properties>
-
   <modules>
     <module>package</module>
+    <module>package-samples</module>
   </modules>
 
   <profiles>
@@ -34,8 +31,15 @@
     <dependencies>
       <dependency>
         <groupId>org.nuxeo.template.rendering</groupId>
+        <artifactId>nuxeo-template-rendering-parent</artifactId>
+        <version>${nuxeo.templates.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.nuxeo.template.rendering</groupId>
         <artifactId>package</artifactId>
-        <version>${marketplace.rendering.version}</version>
+        <version>${maven.project.version}</version>
         <type>zip</type>
       </dependency>
     </dependencies>


### PR DESCRIPTION
As per NXP-17518, packaging is to be made into two different mps, for core functionalities and samples.
Note that merging this pull request has impacts:
- integration scripts => marketplace.ini should be updated
- wizard should be updated
- io instances should deploy the new samples mp
